### PR TITLE
Variable ${framework} in allen Ressourcen-Pfaden nutzen um Erstellung von Erweiterungsframework zu erleichtern

### DIFF
--- a/ediarum.REGISTER.framework
+++ b/ediarum.REGISTER.framework
@@ -4965,7 +4965,7 @@ general_ptr_2</String>
 																<String>&lt;?xml version="1.0" encoding="UTF-8"?>
 &lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="2.0">
-    &lt;xsl:import href="resources/sort_unterorte.xsl"/>
+    &lt;xsl:import href="${framework}/resources/sort_unterorte.xsl"/>
 &lt;/xsl:stylesheet></String>
 															</entry>
 															<entry>

--- a/ediarum.REGISTER.framework
+++ b/ediarum.REGISTER.framework
@@ -1736,7 +1736,7 @@
 																<String>&lt;?xml version="1.0" encoding="UTF-8"?>
 &lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="2.0">
-    &lt;xsl:import href="resources/merge.xsl"/>
+    &lt;xsl:import href="${framework}/resources/merge.xsl"/>
 &lt;/xsl:stylesheet></String>
 															</entry>
 															<entry>
@@ -2785,7 +2785,7 @@
 																<String>&lt;?xml version="1.0" encoding="UTF-8"?>
 &lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="2.0">
-    &lt;xsl:import href="resources/sort.xsl"/>
+    &lt;xsl:import href="${framework}/resources/sort.xsl"/>
 &lt;/xsl:stylesheet></String>
 															</entry>
 															<entry>


### PR DESCRIPTION
Vorschlag für #4 